### PR TITLE
Update roud-permissions.ttl

### DIFF
--- a/roud-permissions.ttl
+++ b/roud-permissions.ttl
@@ -36,10 +36,10 @@
 #
 
 ### Default Object Access Permission on Admin
-<http://rdfh.ch/permissions/0112/roud-oeuvres-o001> a knora-base:DefaultObjectAccessPermission ;
-	knora-base:hasPermissions "CR knora-base:ProjectAdmin|D knora-base:ProjectMember" ;
-	knora-base:forProject <http://rdfh.ch/projects/0112> ;
-	knora-base:forGroup knora-base:ProjectAdmin .
+#<http://rdfh.ch/permissions/0112/roud-oeuvres-o001> a knora-base:DefaultObjectAccessPermission ;
+#	knora-base:hasPermissions "CR knora-base:ProjectAdmin|D knora-base:ProjectMember" ;
+#	knora-base:forProject <http://rdfh.ch/projects/0112> ;
+#	knora-base:forGroup knora-base:ProjectAdmin .
 
 ### Default Object Access Permission on ProjectMember
 <http://rdfh.ch/permissions/0112/roud-oeuvres-o002> a knora-base:DefaultObjectAccessPermission ;


### PR DESCRIPTION
As discussed here https://github.com/dasch-swiss/knora-api/issues/1533, permissions on `ProjectAdmin` and `ProjectMember`groups are redundant. Permission on `ProjectAdmin` can be dropped.