### PR TITLE
Add missing salsah-gui:guiOrder properties.

### DIFF
--- a/roud-onto.ttl
+++ b/roud-onto.ttl
@@ -25,6 +25,7 @@ roud-oeuvres:ArtWork a owl:Class ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:artworkHasPhoto ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "4"^^xsd:nonNegativeInteger ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:artworkHasPhotoValue ],
         [ a owl:Restriction ;
@@ -1830,6 +1831,7 @@ roud-oeuvres:Bioevent a owl:Class ;
     rdfs:comment "An event, or period, of Gustave Roud's biography."@en,
         "Un Événement, ou une période, de la biographie de Gustave Roud."@fr ;
     rdfs:subClassOf [ a owl:Restriction ;
+            salsah-gui:guiOrder "3"^^xsd:nonNegativeInteger ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:bioeventHasPhotoValue ],
         [ a owl:Restriction ;
@@ -1861,6 +1863,7 @@ roud-oeuvres:Book a owl:Class ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:hasPublisher ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "5"^^xsd:nonNegativeInteger ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:hasPublisherValue ],
         [ a owl:Restriction ;
@@ -1889,6 +1892,7 @@ roud-oeuvres:BookSection a owl:Class ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:bookSectionHasPublisher ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "5"^^xsd:nonNegativeInteger ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:bookSectionHasPublisherValue ],
         [ a owl:Restriction ;
@@ -1917,6 +1921,7 @@ roud-oeuvres:PeriodicalArticle a owl:Class ;
             owl:cardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:isPublishedInPeriodical ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "5"^^xsd:nonNegativeInteger ;
             owl:cardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:isPublishedInPeriodicalValue ],
         [ a owl:Restriction ;
@@ -1986,6 +1991,7 @@ roud-oeuvres:Page a owl:Class ;
             owl:cardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:pageIsPartOfManuscript ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "0"^^xsd:nonNegativeInteger ;
             owl:cardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:pageIsPartOfManuscriptValue ],
         [ a owl:Restriction ;
@@ -2025,6 +2031,7 @@ roud-oeuvres:Place a owl:Class ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:placeHasPhoto ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "4"^^xsd:nonNegativeInteger ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:placeHasPhotoValue ],
         knora-base:Resource .
@@ -2059,6 +2066,7 @@ roud-oeuvres:GeneticDossier a owl:Class ;
             owl:cardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:geneticDossierResultsInPublication ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "5"^^xsd:nonNegativeInteger ;
             owl:cardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:geneticDossierResultsInPublicationValue ],
         knora-base:Resource .
@@ -2104,6 +2112,7 @@ roud-oeuvres:Work a owl:Class ;
     rdfs:comment "A work. Abstract class, see subclasses."@en,
         "Une œuvre. Classe abstraite, voir les subclasses."@fr ;
     rdfs:subClassOf [ a owl:Restriction ;
+            salsah-gui:guiOrder "0"^^xsd:nonNegativeInteger ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:workHasAuthorValue ],
         [ a owl:Restriction ;
@@ -2151,6 +2160,7 @@ roud-oeuvres:Photo a owl:Class ;
             owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:photoHasDate ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "3"^^xsd:nonNegativeInteger ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:photoHasAuthorValue ],
         [ a owl:Restriction ;
@@ -2178,6 +2188,7 @@ roud-oeuvres:Person a owl:Class ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:personHasGivenName ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "8"^^xsd:nonNegativeInteger ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:personHasPhotoValue ],
         [ a owl:Restriction ;
@@ -2209,12 +2220,15 @@ roud-oeuvres:Person a owl:Class ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:isReferenceFor ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "11"^^xsd:nonNegativeInteger ;
             owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:personIsSameAsAuthorValue ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "10"^^xsd:nonNegativeInteger ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:isReferenceForValue ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "9"^^xsd:nonNegativeInteger ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:isCharacterInValue ],
         [ a owl:Restriction ;
@@ -2242,6 +2256,7 @@ roud-oeuvres:Publication a owl:Class ;
             owl:cardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:hasPublicationType ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "1"^^xsd:nonNegativeInteger ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:publicationHasAuthorValue ],
         [ a owl:Restriction ;
@@ -2265,6 +2280,7 @@ roud-oeuvres:Publication a owl:Class ;
             owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:publicationIsDigitized ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "10"^^xsd:nonNegativeInteger ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:publicationHasPhotoValue ],
         [ a owl:Restriction ;
@@ -2276,6 +2292,7 @@ roud-oeuvres:Publication a owl:Class ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:publicationHasTitle ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "11"^^xsd:nonNegativeInteger ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:publicationIsEditionOfValue ],
         [ a owl:Restriction ;
@@ -2359,6 +2376,7 @@ roud-oeuvres:Manuscript a owl:Class ;
             owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:manuscriptHasDateEstablishedComputable ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "20"^^xsd:nonNegativeInteger ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:hasTranslatedAuthorValue ],
         [ a owl:Restriction ;
@@ -2378,6 +2396,7 @@ roud-oeuvres:Manuscript a owl:Class ;
             owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:manuscriptHasDateEstablishedList ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "17"^^xsd:nonNegativeInteger ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:manuscriptHasPublishedReferenceValue ],
         [ a owl:Restriction ;
@@ -2417,6 +2436,7 @@ roud-oeuvres:EstablishedText a owl:Class ;
             owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:hasDirectSourcePublication ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "13"^^xsd:nonNegativeInteger ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:publicationReusedInNewTextValue ],
         [ a owl:Restriction ;
@@ -2428,6 +2448,7 @@ roud-oeuvres:EstablishedText a owl:Class ;
             owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:establishedTextHasEditorialSet ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "3"^^xsd:nonNegativeInteger ;
             owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:hasDirectSourcePublicationValue ],
         [ a owl:Restriction ;
@@ -2439,6 +2460,7 @@ roud-oeuvres:EstablishedText a owl:Class ;
             owl:cardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:establishedTextHasTitle ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "10"^^xsd:nonNegativeInteger ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:diaryReusedInValue ],
         [ a owl:Restriction ;
@@ -2450,6 +2472,7 @@ roud-oeuvres:EstablishedText a owl:Class ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:publicationIsReissued ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "6"^^xsd:nonNegativeInteger ;
             owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:hasDirectSourcePageEndValue ],
         [ a owl:Restriction ;
@@ -2473,6 +2496,7 @@ roud-oeuvres:EstablishedText a owl:Class ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:publicationReusedInNewText ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "13"^^xsd:nonNegativeInteger ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:publicationIsReissuedValue ],
         [ a owl:Restriction ;
@@ -2488,9 +2512,11 @@ roud-oeuvres:EstablishedText a owl:Class ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:diaryRewrittenInDiary ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "11"^^xsd:nonNegativeInteger ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:manuscriptIsPartOfGeneticDossierValue ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "14"^^xsd:nonNegativeInteger ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:publicationPartiallyReusedInCollectionValue ],
         [ a owl:Restriction ;
@@ -2498,12 +2524,15 @@ roud-oeuvres:EstablishedText a owl:Class ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:diaryReusedIn ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "12"^^xsd:nonNegativeInteger ;
             owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:isBeforeInAvantTexteValue ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "9"^^xsd:nonNegativeInteger ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:diaryRewrittenInDiaryValue ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "2"^^xsd:nonNegativeInteger ;
             owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:hasDirectSourceManuscriptValue ],
         [ a owl:Restriction ;
@@ -2511,6 +2540,7 @@ roud-oeuvres:EstablishedText a owl:Class ;
             owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:hasDirectSourcePosition ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "15"^^xsd:nonNegativeInteger ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:publicationFullyReusedInCollectionValue ],
         [ a owl:Restriction ;
@@ -2522,6 +2552,7 @@ roud-oeuvres:EstablishedText a owl:Class ;
             owl:cardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:isInPaperEdition ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder "5"^^xsd:nonNegativeInteger ;
             owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:hasDirectSourcePageStartValue ],
         [ a owl:Restriction ;


### PR DESCRIPTION
- this PR adds `salsah-gui:guiOrder` in class definitions for subproperties of `knora-base:hasLinkToValue`.  

These properties should have the same `salsah-gui:guiOrder` as the subproperties of `knora-base:hasLinkToValue`, e.g. `publicationReusedInNewText` and `publicationReusedInNewText`.

Closes #28 
