### PR TITLE
Add archives list node

### DIFF
--- a/roud-data-lists.ttl
+++ b/roud-data-lists.ttl
@@ -103,7 +103,8 @@
     <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-ALSChappaz>,
     <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-ALSChessex>,
     <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-ALSSES>,
-    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-ALSFrançoisDaulte>;
+    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-ALSFrançoisDaulte>,
+    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-ALSArchiv>;
   knora-base:isRootNode true;
   knora-base:attachedToProject <http://rdfh.ch/projects/0112>;
   rdfs:comment "Archive dans le quel se trouve le document ou la publication"@fr;
@@ -532,6 +533,12 @@
   knora-base:listNodeName "ALSFrançoisDaulte";
   knora-base:listNodePosition 14;
   rdfs:label "ALS François Daulte"@en, "ALS François Daulte"@fr .
+
+<http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-ALSArchiv> a knora-base:ListNode;
+  knora-base:hasRootNode <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive>;
+  knora-base:listNodeName "ALSArchiv";
+  knora-base:listNodePosition 14;
+  rdfs:label "ALS"@en, "ALS"@fr .
 
 
 <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInEdition-oui> a knora-base:ListNode;

--- a/roud-data-lists.ttl
+++ b/roud-data-lists.ttl
@@ -93,7 +93,7 @@
     <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-BCUSimond>, <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-BiblioChauxDeFonds>,
     <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-CRLRColomb>, <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-CRLRGR>,
     <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-CRLRMermod>, <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-CRLRStevenPaulRobert>,
-    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-CollectionPrivee>;
+    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-CollectionPrivee>, <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-ALSFrançoisDaulte>;
   knora-base:isRootNode true;
   knora-base:attachedToProject <http://rdfh.ch/projects/0112>;
   rdfs:comment "Archive dans le quel se trouve le document ou la publication"@fr;
@@ -516,6 +516,13 @@
   knora-base:listNodeName "ALSSES";
   knora-base:listNodePosition 13;
   rdfs:label "ALS SES"@en, "ALS SES"@fr .
+
+<http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-ALSFrançoisDaulte> a knora-base:ListNode;
+  knora-base:hasRootNode <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive>;
+  knora-base:listNodeName "ALSFrançoisDaulte";
+  knora-base:listNodePosition 14;
+  rdfs:label "ALS François Daulte"@en, "ALS François Daulte"@fr .
+
 
 <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInEdition-oui> a knora-base:ListNode;
   knora-base:hasRootNode <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInEdition>;

--- a/roud-data-lists.ttl
+++ b/roud-data-lists.ttl
@@ -88,12 +88,22 @@
   rdfs:label "L'instrument d'écriture"@fr .
 
 <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive> a knora-base:ListNode;
-  knora-base:hasSubListNode <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-BCUChevalley>,
-    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-BCUGuildeDuLivre>, <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-BCUHutterPerrier>,
-    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-BCUSimond>, <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-BiblioChauxDeFonds>,
-    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-CRLRColomb>, <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-CRLRGR>,
-    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-CRLRMermod>, <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-CRLRStevenPaulRobert>,
-    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-CollectionPrivee>, <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-ALSFrançoisDaulte>;
+  knora-base:hasSubListNode
+    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-CRLRGR>,
+    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-CRLRMermod>,
+    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-CRLRColomb>,
+    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-BCUSimond>,
+    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-BCUChevalley>,
+    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-BCUGuildeDuLivre>,
+    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-BCUHutterPerrier>,
+    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-BiblioChauxDeFonds>,
+    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-CollectionPrivee>,
+    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-CRLRStevenPaulRobert>,
+    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-CRLRGilbertVincent>,
+    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-ALSChappaz>,
+    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-ALSChessex>,
+    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-ALSSES>,
+    <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive-ALSFrançoisDaulte>;
   knora-base:isRootNode true;
   knora-base:attachedToProject <http://rdfh.ch/projects/0112>;
   rdfs:comment "Archive dans le quel se trouve le document ou la publication"@fr;


### PR DESCRIPTION
Need to add a new node to the list of archives in which the manuscripts are kept. The new archive is "ALS François Daulte".

In doing that, realize that there were other nodes missing from the list of subListNodes for <http://rdfh.ch/lists/0112/roud-oeuvres-flatlist-isInArchive>, even defined as listNodes below in the turtle. Added them and reorder the list of subListNodes.