### PR TITLE
change cardinality of property manuscriptHasEditorialSet

### DIFF
--- a/roud-onto.ttl
+++ b/roud-onto.ttl
@@ -2783,7 +2783,7 @@ roud-oeuvres:Manuscript a owl:Class ;
             owl:onProperty roud-oeuvres:manuscriptHasOldShelfmark ],
         [ a owl:Restriction ;
             salsah-gui:guiOrder "4"^^xsd:nonNegativeInteger ;
-            owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+            owl:minCardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty roud-oeuvres:manuscriptHasEditorialSet ],
         [ a owl:Restriction ;
             salsah-gui:guiOrder "5"^^xsd:nonNegativeInteger ;


### PR DESCRIPTION
Change of cardinality for property `:manuscriptHasEditorialSet`, in order to allow multiple values for the same document. This is important when there are various texts on the same documents, for example a diary note and the draft of a translation. We want to be able to say that the document belongs both to the editorial set "Diary" and "Translation".